### PR TITLE
Apply Refactor/prl-mush-team

### DIFF
--- a/Classes/MushMatch.uc
+++ b/Classes/MushMatch.uc
@@ -846,8 +846,6 @@ state GameStarted
 
                 if (PRL == None) continue;
                 if (PRL.bMush) continue;
-
-                b = true;
             
                 if (FRand() * NumChoices < 1.0) {
                     Selected = Curr;

--- a/Classes/MushMatch.uc
+++ b/Classes/MushMatch.uc
@@ -530,9 +530,9 @@ function MushMatchPRL FindPawnPRL(Pawn Other) {
 }
 
 function MakeMush(Pawn Other, Pawn Instigator) {
-    local MushMatchPRL MRPL;
+    local MushMatchPRL MPRL;
 
-    MRPL = FindPawnPRL(Other);
+    MPRL = FindPawnPRL(Other);
 
     if (MPRL == None) {
         Warn("MakeMush could not find MushMatchPRL for"@ Other);

--- a/Classes/MushMatch.uc
+++ b/Classes/MushMatch.uc
@@ -532,7 +532,7 @@ function MushMatchPRL FindPawnPRL(Pawn Other) {
 function MakeMush(Pawn Other, Pawn Instigator) {
     local MushMatchPRL MRPL;
 
-    MPRL = FindPawnPRL(Other);
+    MRPL = FindPawnPRL(Other);
 
     if (MPRL == None) {
         Warn("MakeMush could not find MushMatchPRL for"@ Other);
@@ -541,7 +541,7 @@ function MakeMush(Pawn Other, Pawn Instigator) {
 
     SafeGiveSporifier(Other);
     
-    FindPawnPRL.bMush = true;
+    MPRL.bMush = true;
     Other.PlayerReplicationInfo.Score *= InfectionScoreMultiplier;
         
     if (MushMatch(Level.Game).CheckEnd()) {

--- a/Classes/MushMatchHUD.uc
+++ b/Classes/MushMatchHUD.uc
@@ -75,7 +75,7 @@ simulated event PostRender(Canvas Drawer)
         Drawer.DrawColor = HUDColor * 0.75;
         Drawer.SetPos(Drawer.SizeX * 0.475, 0);
 
-        if ( !PlayerPRL.bMush == 0 ) {
+        if (!PlayerPRL.bMush) {
             Drawer.DrawIcon(Texture'MMHUDHuman', FlatSize);
 
             if (PlayerPRL.ImmuneLevel < 1) {

--- a/Classes/MushMatchHUD.uc
+++ b/Classes/MushMatchHUD.uc
@@ -75,7 +75,7 @@ simulated event PostRender(Canvas Drawer)
         Drawer.DrawColor = HUDColor * 0.75;
         Drawer.SetPos(Drawer.SizeX * 0.475, 0);
 
-        if ( PlayerOwner.PlayerReplicationInfo.Team == 0 ) {
+        if ( !PlayerPRL.bMush == 0 ) {
             Drawer.DrawIcon(Texture'MMHUDHuman', FlatSize);
 
             if (PlayerPRL.ImmuneLevel < 1) {

--- a/Classes/MushMatchInfo.uc
+++ b/Classes/MushMatchInfo.uc
@@ -211,6 +211,10 @@ simulated function bool CheckDead(PlayerReplicationInfo Other)
 
 simulated event string TeamText(PlayerReplicationInfo PRI, PlayerPawn Other)
 {
+    local MushMatchPRL OtherPRL;
+
+    OtherPRL = FindPRL(Other.PlayerReplicationInfo);
+
     if (CheckDead(PRI)) {
         if ( PRI.Team == 1 )
             return "Mush (dead)";
@@ -220,7 +224,7 @@ simulated event string TeamText(PlayerReplicationInfo PRI, PlayerPawn Other)
     }
 
     if (bMushSelected) {
-        if ( Other.PlayerReplicationInfo == PRI || Other.PlayerReplicationInfo.Team == 1 || bMatchEnd || CheckDead(Other.PlayerReplicationInfo) ) {
+        if (Other.PlayerReplicationInfo == PRI || (OtherPRL != None && OtherPRL.bMush) || bMatchEnd || CheckDead(Other.PlayerReplicationInfo)) {
             if ( PRI.Team == 1 ) {
                 if ( CheckBeacon(PRI) )
                     return "Mush (susp.)";
@@ -265,6 +269,9 @@ simulated event string TeamText(PlayerReplicationInfo PRI, PlayerPawn Other)
 simulated event string TeamTextAlignment(PlayerReplicationInfo PRI, PlayerPawn Other)
 {
     local MushMatchPRL MPRL;
+    local MushMatchPRL OtherPRL;
+    
+    OtherPRL = FindPRL(Other.PlayerReplicationInfo);
 
     if (CheckDead(PRI)) {
         if (PRI.Team == 1) {
@@ -284,7 +291,7 @@ simulated event string TeamTextAlignment(PlayerReplicationInfo PRI, PlayerPawn O
     }
 
     if (bMushSelected) {
-        if (Other.PlayerReplicationInfo == PRI || Other.PlayerReplicationInfo.Team == 1 || bMatchEnd || CheckDead(Other.PlayerReplicationInfo)) {
+        if (Other.PlayerReplicationInfo == PRI || (OtherPRL != None && OtherPRL.bMush) || bMatchEnd || CheckDead(Other.PlayerReplicationInfo)) {
             if (PRI.Team == 1) {
                 MPRL = FindPRL(PRI);
             
@@ -350,7 +357,7 @@ function byte MushMatchAssessBotAttitude(Pawn aBot, Pawn Other) {
     local MushMatchInfo MMI;
     local bool bNoSneaking;
     local PlayerReplicationInfo BotPRI, OtherPRI;
-    local MushMatchPRL BotMPRL, OtherMPRL;
+    local MushMatchPRL BotMPRL, OtherMPRL, PPRL;
     local Sporifier sporer;
     local MushMatch MM;
 
@@ -405,7 +412,19 @@ function byte MushMatchAssessBotAttitude(Pawn aBot, Pawn Other) {
             // maybe try to infect, if you can be sneaky!
             if (!Other.CanSee(aBot) && aBot.FindInventoryType(class'Sporifier') != None && FRand() < DecideChance_Infect && !aBot.IsInState('attacking')) {
                 for (P = Level.PawnList; P != None; P = P.NextPawn) {
-                    if (P.bIsPlayer && P.PlayerReplicationInfo != None && P.PlayerReplicationInfo.Team == 0 && P.LineOfSightTo(aBot) && P != Other) {
+                    if (!P.bIsPlayer) continue;
+                    if (P.PlayerReplicationInfo == None) continue;
+                
+                    PPRL = MMI.FindPRL(P.PlayerReplicationInfo);
+
+                    if (PPRL == None) {
+                        Error("Found a bIsPlayer Pawn with PlayerReplicationInfo but no MushMatchPRL:"@ P);
+                        continue;
+                    }
+
+                    if (PPRL.bMush) continue;
+                
+                    if (P.LineOfSightTo(aBot) && P != Other) {
                         bNoSneaking = true;
                     }
                 }

--- a/Classes/MushMatchMutator.uc
+++ b/Classes/MushMatchMutator.uc
@@ -41,7 +41,7 @@ simulated function Tick(float TimeDelta) {
     if (!bHUDMutator && Level.NetMode != NM_DedicatedServer) {
         Log("Consider registering MushMatchMutator as HUD in the clientside");
 
-        if (FindLocalPlayer()) {
+        if (FindLocalPlayer() != None) {
             Log("Local player found, register MushMatchMutator as HUD mutator");
             RegisterHUDMutator();
         }

--- a/Classes/MushMatchMutator.uc
+++ b/Classes/MushMatchMutator.uc
@@ -610,7 +610,7 @@ simulated function bool HUD_DrawSpecialIdentifyInfo(Canvas Drawer, PlayerReplica
     }
     */
 
-    if (Level.NetMode == NM_Dedicated) {
+    if (Level.NetMode == NM_DedicatedServer) {
         // Serverside HUD? whut?
         return false;
     }

--- a/Classes/MushMatchPRL.uc
+++ b/Classes/MushMatchPRL.uc
@@ -1,8 +1,8 @@
 class MushMatchPRL extends PlayerReplicationList;
 
 var             bool                    bIsSuspected;
-var             bool                    bKnownMush;
-var             bool                    bKnownHuman;
+var             bool                    bMush;
+var             bool                    bKnownMush, bKnownHuman;
 var             bool                    bDead;
 var             byte                    InitialTeam;
 var             float                   ImmuneLevel;
@@ -27,7 +27,7 @@ var(MushMatch)  config bool             bImmuneNaturallyTendsToFull,
 replication
 {
     reliable if (Role == ROLE_Authority)
-        bIsSuspected, bKnownHuman, bKnownMush, bDead, HatedBy, InitialTeam,
+        bIsSuspected, bMush, bKnownHuman, bKnownMush, bDead, InitialTeam, HatedBy,
 
         // immune level and its parameters
         ImmuneLevel, ImmuneResistance, ImmuneMomentum, ImmuneMomentumThreshold, ImmuneMomentumDrag,

--- a/Classes/MushMatchPRL.uc
+++ b/Classes/MushMatchPRL.uc
@@ -3,7 +3,7 @@ class MushMatchPRL extends PlayerReplicationList;
 var             bool                    bIsSuspected;
 var             bool                    bMush;
 var             bool                    bKnownMush, bKnownHuman;
-var             bool                    bDead;
+var             bool                    bDead, bSpectator;
 var             byte                    InitialTeam;
 var             float                   ImmuneLevel;
 var             float                   ImmuneMomentum, ImmuneResistance;
@@ -196,6 +196,8 @@ defaultproperties
     bKnownMush=false
     bKnownHuman=false
     bDead=false
+    bSpectator=false
+    bMush=false
     HatedBy=none
     ImmuneLevel=1.0
     ImmuneMomentum=0.0

--- a/Classes/SporeProj.uc
+++ b/Classes/SporeProj.uc
@@ -47,7 +47,7 @@ simulated function Tick(float TimeDelta)
 function ProcessTouch(Actor Other, Vector HitLocation)
 {
     local Pawn mushed;
-    local MushMatchPRL OtherPRL;
+    local MushMatchPRL InstigPRL, OtherPRL;
 
     // Pass through instigator
 
@@ -68,26 +68,25 @@ function ProcessTouch(Actor Other, Vector HitLocation)
         return;
     }
 
-    if (Pawn(Other) != None && Pawn(Other).bIsPlayer && Pawn(Other).PlayerReplicationInfo != None && Instigator.PlayerReplicationInfo != None && Instigator.PlayerReplicationInfo.Team == 1) {
+    if (Instigator.PlayerReplicationInfo != None) {
+        InstigPRL = MushMatchInfo(Level.Game.GameReplicationInfo).FindPRL(Instigator.PlayerReplicationInfo);
+    }
+
+    if (Pawn(Other) != None && Pawn(Other).bIsPlayer && Pawn(Other).PlayerReplicationInfo != None && InstigPRL != None && InstigPRL.bMush) {
         mushed = Pawn(Other);
 
-        if (mushed.PlayerReplicationInfo.Team == 0) {
-            OtherPRL = MushMatchInfo(Level.Game.GameReplicationInfo).FindPRL(mushed.PlayerReplicationInfo);
-
-            if (OtherPRL == None) {
-                Warn("Couldn't find MushMatchPRL for"@ mushed.PlayerReplicationInfo.PlayerName @"("$ mushed $"); couldn't try mushing them!");
-                return;
-            }
-
-            OtherPRL.TryToMush(Instigator);
+        OtherPRL = MushMatchInfo(Level.Game.GameReplicationInfo).FindPRL(mushed.PlayerReplicationInfo);
+        
+        if (OtherPRL == None) {
+            Error("Couldn't find MushMatchPRL for"@ mushed.PlayerReplicationInfo.PlayerName @"("$ mushed $") even though they are bIsPlayer; couldn't try mushing them!");
         }
 
-        Destroy();
+        if (!OtherPRL.bMush) {
+            OtherPRL.TryToMush(Instigator);
+        }
     }
 
-    else {
-        Super.ProcessTouch(Other, HitLocation);
-    }
+    Super.ProcessTouch(Other, HitLocation);
 }
 
 defaultproperties

--- a/Classes/Sporifier.uc
+++ b/Classes/Sporifier.uc
@@ -111,12 +111,12 @@ simulated function FindOwnPRL() {
     FindMMI();
 
     if (PRL != None && PRL.Owner == Pawn(Owner).PlayerReplicationInfo) {
-        return PRL;
+        return;
     }
 
     PRL = MMI.FindPRL(Pawn(Owner).PlayerReplicationInfo);
 
-    return PRL;
+    return;
 }
 
 simulated function FindMMI() {

--- a/Classes/Sporifier.uc
+++ b/Classes/Sporifier.uc
@@ -134,9 +134,7 @@ simulated function FindMMI() {
 }
 
 simulated function Tick(float TimeDelta)
-{
-    local Pawn p;
-    
+{   
     Super.Tick(TimeDelta);
         
     if ( Owner == None || Owner.IsInState('Dying') || ( MushMatch(Level.Game) == none && Pawn(Owner).PlayerReplicationInfo != none && Pawn(Owner).PlayerReplicationInfo.Deaths > 0 ) )
@@ -182,6 +180,7 @@ simulated function Tick(float TimeDelta)
 
 function CheckSpotted() {
     local MushMatchPRL PPRL;
+    local Pawn p;
     
     for (p = Level.PawnList; p != none; p = p.nextPawn) {
         if (!p.bIsPlayer) continue;

--- a/Classes/Sporifier.uc
+++ b/Classes/Sporifier.uc
@@ -36,6 +36,8 @@ class Sporifier extends TournamentWeapon;
 
 var float SafeTime;
 var bool bDesired;
+var MushMatchInfo MMI;
+var MushMatchPRL PRL;
 
 var(MushMatch) config float SporifierFirerate, SporifierAIMaxSafeTime;
 
@@ -105,10 +107,35 @@ simulated function PlayIdle()
     PlayAnim('Still', 0.35, 0.5);
 }
 
+simulated function FindOwnPRL() {
+    FindMMI();
+
+    if (PRL != None && PRL.Owner == Pawn(Owner).PlayerReplicationInfo) {
+        return PRL;
+    }
+
+    PRL = MMI.FindPRL(Pawn(Owner).PlayerReplicationInfo);
+
+    return PRL;
+}
+
+simulated function FindMMI() {
+    if (MMI != None) {
+        return;
+    }
+
+    if (Role == ROLE_Authority) {
+        MMI = MushMatchInfo(Level.Game.GameReplicationInfo);
+    }
+
+    else {
+        MMI = MushMatchInfo(PlayerPawn(Owner).GameReplicationInfo);
+    }
+}
+
 simulated function Tick(float TimeDelta)
 {
     local Pawn p;
-    local MushMatchPRL PRL;
     
     Super.Tick(TimeDelta);
         
@@ -123,27 +150,24 @@ simulated function Tick(float TimeDelta)
         return;
     }
     
-    if (Pawn(Owner).Weapon != self) {
+    if (Pawn(Owner).Weapon != Self) {
         return;
     }
 
-    if (Role == ROLE_Authority) {    
-        for ( p = Level.PawnList; p != none; p = p.nextPawn ) {
-            if ( p.bIsPlayer && p != Owner && p.PlayerReplicationInfo != none && p.PlayerReplicationInfo.Deaths <= 0 && p.CanSee(Owner) && Pawn(Owner).PlayerReplicationInfo.Team == 1  && p.PlayerReplicationInfo.Team == 0 ) {
-                MushMatch(Level.Game).SpotMush(Pawn(Owner), p);
-                break;
-            }
-        }
-    }
-
-    PRL = MushMatchInfo(Level.Game.GameReplicationInfo).FindPRL(Pawn(Owner).PlayerReplicationInfo);
-
+    FindOwnPRL();
+    
     if (PRL == None) {
         return;
     }
 
     if (PRL.bKnownMush) {
         return;
+    }
+
+    if (Role == ROLE_Authority) {    
+        if (!IsInState('BringUp') && AnimSequence != 'Select') {
+            CheckSpotted();
+        }
     }
 
     SafeTime += TimeDelta;
@@ -153,6 +177,27 @@ simulated function Tick(float TimeDelta)
             bDesired = false; // just in case we don't get put down
             Pawn(Owner).SwitchToBestWeapon();
         }
+    }
+}
+
+function CheckSpotted() {
+    local MushMatchPRL PPRL;
+    
+    for (p = Level.PawnList; p != none; p = p.nextPawn) {
+        if (!p.bIsPlayer) continue;
+        if (p == Owner) continue;
+        if (p.PlayerReplicationInfo == none) continue;
+
+        PPRL = MMI.FindPRL(P.PlayerReplicationInfo);
+
+        if (PPRL == None) continue;
+        if (PPRL.bDead) continue;
+        if (PPRL.bMush) continue;
+
+        if (!p.CanSee(Owner)) continue;
+
+        MushMatch(Level.Game).SpotMush(Pawn(Owner), p);
+        break;
     }
 }
 

--- a/_build.sh
+++ b/_build.sh
@@ -59,7 +59,7 @@ cleanup() {
             #WINEPREFIX="$wineprefix" wine "$umake" "$package-$build"
             if [[ -f "$packagefull.u" ]]; then rm "$packagefull.u"; fi
             echo "* Invoking ucc make in $(pwd)"
-            ( "$ucc" make -NoBind ini="$TMP_INI" || exit 1 ) | tee "$packagedir/make.log"
+            "$ucc" make -NoBind ini="$TMP_INI" | tee "$packagedir/make.log"
 
             # Ensure .u is built
             if [[ ! -f "$packagefull.u" ]]; then
@@ -70,7 +70,8 @@ cleanup() {
                     exit 1
                 fi
             fi
-        ) || exit $?
+        )
+        code=$?; echo $code; [[ $code == 0 ]] && exit $codef
 
         # Format .int with Mustache
         echo "Formatting: System/$package.int"
@@ -97,7 +98,6 @@ cleanup() {
         rm -f "$dist/$package/latest/*"
         cp "$dist/$package/$build/"* "$dist/$package/latest"
     )
-    code=$?
     exit $?
 )
 code=$?

--- a/buildconfig.sh
+++ b/buildconfig.sh
@@ -3,7 +3,7 @@
 # Edit this file if necessary; it is read by _build.sh in order to
 # provide some context variables.
 
-export build=20213921
+export build=20213922
 export version=1.3.0
 export debug=1
 export package=MushMatch


### PR DESCRIPTION
This refactor undoes the dependency on `PlayerReplicationInfo.Team` in `MushMatch` that can interfere in other code, such as other mods, or make unfair, such as by the colour of the shield belt forcefield or the Translocator disk light.

This is a pull request so it can be verified by CI.